### PR TITLE
Introduce MANAGE_EXTERNAL_STORAGE permission to get all files access

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.filemanager">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     package="com.example.filemanager">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,10 +10,10 @@
         tools:ignore="ScopedStorage" />
 
     <application
-        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.FileManager">

--- a/app/src/main/java/com/example/filemanager/AllFilesFragment.kt
+++ b/app/src/main/java/com/example/filemanager/AllFilesFragment.kt
@@ -8,12 +8,10 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.Settings
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -28,16 +26,11 @@ class AllFilesFragment : Fragment(), ItemClickListener {
     private lateinit var binding: FragmentAllFilesBinding
     private lateinit var viewModel: AllFilesViewModel
 
-    companion object {
-        const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 333
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel = ViewModelProvider(this, AllFilesViewModelFactory(applicationContext()))
             .get(AllFilesViewModel::class.java)
         adapter = ListAdapter(this)
-        fetchFiles()
     }
 
     override fun onCreateView(
@@ -67,13 +60,18 @@ class AllFilesFragment : Fragment(), ItemClickListener {
         })
     }
 
+    override fun onStart() {
+        super.onStart()
+        fetchFiles()
+    }
+
     override fun onItemClickListener() {
         Toast.makeText(context, "Item clicked", Toast.LENGTH_SHORT).show()
     }
 
     private fun fetchFiles() {
         if (!checkPermission()) {
-            showPermissionDialog();
+            showPermissionDialog()
         } else {
             viewModel.fetchFiles()
         }
@@ -81,23 +79,16 @@ class AllFilesFragment : Fragment(), ItemClickListener {
 
     private fun showPermissionDialog() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            try {
-                val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
-                intent.addCategory("android.intent.category.DEFAULT")
-                intent.data = Uri.parse(String.format("package:%s", arrayOf<Any>(applicationContext().packageName)))
-                activity?.startActivityForResult(intent, 2000)
-            } catch (e: Exception) {
-                val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
-                activity?.startActivityForResult(intent, 2000)
-            }
-        } else {
-            ActivityCompat.requestPermissions(
-                requireActivity(),
-                arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE),
-                PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE
+            val uri = Uri.parse("package:${BuildConfig.APPLICATION_ID}")
+            startActivity(
+                Intent(
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri
+                )
             )
-            Log.d("RequestPermission", "Requesting permission")
-        }
+        } else requestPermissions(
+            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+            PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE
+        )
     }
 
     private fun checkPermission(): Boolean {
@@ -108,24 +99,16 @@ class AllFilesFragment : Fragment(), ItemClickListener {
                 applicationContext(),
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
             )
-            val read = ContextCompat.checkSelfPermission(
-                applicationContext(),
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            )
-            write == PackageManager.PERMISSION_GRANTED &&
-                    read == PackageManager.PERMISSION_GRANTED
+            write == PackageManager.PERMISSION_GRANTED
         }
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String?>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        Log.d("OnPermissionResult", "on permission result is here")
         if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE) {
             if (grantResults.isNotEmpty()) {
                 val write = grantResults[0] == PackageManager.PERMISSION_GRANTED
-                val read = grantResults[1] == PackageManager.PERMISSION_GRANTED
-                if (read && write) {
-                    Toast.makeText(context, "Permission allowed", Toast.LENGTH_SHORT).show()
+                if (write) {
+                    fetchFiles()
                 } else {
                     Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
                 }
@@ -133,15 +116,7 @@ class AllFilesFragment : Fragment(), ItemClickListener {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == 2000) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                if (Environment.isExternalStorageManager()) {
-                    Toast.makeText(context, "Permission allowed", Toast.LENGTH_SHORT).show()
-                } else {
-                    Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
+    companion object {
+        const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 333
     }
 }

--- a/app/src/main/java/com/example/filemanager/AllFilesFragment.kt
+++ b/app/src/main/java/com/example/filemanager/AllFilesFragment.kt
@@ -1,12 +1,20 @@
 package com.example.filemanager
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -26,7 +34,11 @@ class AllFilesFragment : Fragment(), ItemClickListener {
         viewModel = ViewModelProvider(this, AllFilesViewModelFactory(applicationContext()))
             .get(AllFilesViewModel::class.java)
         adapter = ListAdapter(this)
-        viewModel.fetchFiles()
+        if (!checkPermission()) {
+            showPermissionDialog();
+        } else {
+            viewModel.fetchFiles()
+        }
     }
 
     override fun onCreateView(
@@ -58,5 +70,66 @@ class AllFilesFragment : Fragment(), ItemClickListener {
 
     override fun onItemClickListener() {
         Toast.makeText(context, "Item clicked", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun showPermissionDialog() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+                intent.addCategory("android.intent.category.DEFAULT")
+                intent.data = Uri.parse(String.format("package:%s", arrayOf<Any>(applicationContext().packageName)))
+                activity?.startActivityForResult(intent, 2000)
+            } catch (e: Exception) {
+                val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+                activity?.startActivityForResult(intent, 2000)
+            }
+        } else ActivityCompat.requestPermissions(
+            super.requireActivity(),
+            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE),
+            333
+        )
+    }
+
+    private fun checkPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Environment.isExternalStorageManager()
+        } else {
+            val write = ContextCompat.checkSelfPermission(
+                applicationContext(),
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+            val read = ContextCompat.checkSelfPermission(
+                applicationContext(),
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            )
+            write == PackageManager.PERMISSION_GRANTED &&
+                    read == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String?>, grantResults: IntArray) {
+        if (requestCode == 333) {
+            if (grantResults.isNotEmpty()) {
+                val write = grantResults[0] == PackageManager.PERMISSION_GRANTED
+                val read = grantResults[1] == PackageManager.PERMISSION_GRANTED
+                if (read && write) {
+                    Toast.makeText(context, "Permission allowed", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == 2000) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                if (Environment.isExternalStorageManager()) {
+                    Toast.makeText(context, "Permission allowed", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/filemanager/AllFilesFragment.kt
+++ b/app/src/main/java/com/example/filemanager/AllFilesFragment.kt
@@ -85,29 +85,31 @@ class AllFilesFragment : Fragment(), ItemClickListener {
                     Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri
                 )
             )
-        } else requestPermissions(
-            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
-            PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE
-        )
+        } else {
+            requestPermissions(
+                arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE
+            )
+        }
     }
 
     private fun checkPermission(): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             Environment.isExternalStorageManager()
         } else {
-            val write = ContextCompat.checkSelfPermission(
+            val writePermission = ContextCompat.checkSelfPermission(
                 applicationContext(),
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
             )
-            write == PackageManager.PERMISSION_GRANTED
+            writePermission == PackageManager.PERMISSION_GRANTED
         }
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String?>, grantResults: IntArray) {
         if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE) {
             if (grantResults.isNotEmpty()) {
-                val write = grantResults[0] == PackageManager.PERMISSION_GRANTED
-                if (write) {
+                val writePermission = grantResults[0] == PackageManager.PERMISSION_GRANTED
+                if (writePermission) {
                     fetchFiles()
                 } else {
                     Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/filemanager/AllFilesViewModel.kt
+++ b/app/src/main/java/com/example/filemanager/AllFilesViewModel.kt
@@ -1,9 +1,7 @@
 package com.example.filemanager
 
-import android.os.Build
 import android.os.Environment
 import android.util.Log
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import java.io.File
@@ -12,7 +10,6 @@ class AllFilesViewModel() : ViewModel() {
 
     val files = MutableLiveData<List<ListModel>>()
 
-    @RequiresApi(Build.VERSION_CODES.R)
     fun fetchFiles() {
         val path = Environment.getExternalStorageDirectory().absolutePath ?: return
         Log.d("PATH", path)

--- a/app/src/main/java/com/example/filemanager/MainActivity.kt
+++ b/app/src/main/java/com/example/filemanager/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.example.filemanager
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
### Description:
 * In this PR I introduce the MANAGE_EXTERNAL_STORAGE in the manifest file to get access to all files from the device, like:
   ``` <uses-permission
        android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />```
  * Also I added read and write permissions and at the application tag android:requestLegacyExternalStorage="true"
  * In ```AllFilesFragment.kt``` I made a check if permissions are enabled or disabled. If not is shown the permission dialog

### Results:
![241670829_884747462463021_1227280947981015252_n](https://user-images.githubusercontent.com/55796198/132959185-30cafefd-d7ee-488c-a2cb-0109f8da4d4d.jpg)
![241686490_457302205350430_8426060007600462944_n](https://user-images.githubusercontent.com/55796198/132959187-b34543a4-8794-4f92-a72c-4e69659cf7a9.jpg)
![241666464_548070693194816_7038337126747225947_n](https://user-images.githubusercontent.com/55796198/132959193-b517a4bd-3dae-4b9d-9ba9-4f73c89476ad.jpg)

